### PR TITLE
Fixing observer not being released

### DIFF
--- a/Making MVC Greate Again/Base/Protocols/KeyboardControllable.swift
+++ b/Making MVC Greate Again/Base/Protocols/KeyboardControllable.swift
@@ -82,28 +82,28 @@ extension KeyboardObserving where Self: UIViewController {
     
     /// Register for UIKeyboard notifications.
     func registerForKeyboardEvents() {
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: nil) { notification in
-            self.keyboardWillShow(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardWillShow(notification)
         }
         
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: nil) { notification in
-            self.keyboardDidShow(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardDidShow(notification)
         }
         
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: nil) { notification in
-            self.keyboardWillHide(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardWillHide(notification)
         }
         
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidHideNotification, object: nil, queue: nil) { notification in
-            self.keyboardDidHide(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidHideNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardDidHide(notification)
         }
         
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillChangeFrameNotification, object: nil, queue: nil) { notification in
-            self.keyboardWillChangeFrame(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillChangeFrameNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardWillChangeFrame(notification)
         }
         
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidChangeFrameNotification, object: nil, queue: nil) { notification in
-            self.keyboardDidChangeFrame(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidChangeFrameNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardDidChangeFrame(notification)
         }
     }
     

--- a/Making MVC Greate Again/Base/Protocols/KeyboardObserving.swift
+++ b/Making MVC Greate Again/Base/Protocols/KeyboardObserving.swift
@@ -85,28 +85,28 @@ extension KeyboardObserving where Self: UIViewController {
     
     /// Register for UIKeyboard notifications.
     func registerForKeyboardEvents() {
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: nil) { notification in
-            self.keyboardWillShow(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardWillShow(notification)
         }
         
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: nil) { notification in
-            self.keyboardDidShow(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardDidShow(notification)
         }
         
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: nil) { notification in
-            self.keyboardWillHide(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardWillHide(notification)
         }
         
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidHideNotification, object: nil, queue: nil) { notification in
-            self.keyboardDidHide(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidHideNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardDidHide(notification)
         }
         
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillChangeFrameNotification, object: nil, queue: nil) { notification in
-            self.keyboardWillChangeFrame(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillChangeFrameNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardWillChangeFrame(notification)
         }
         
-        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidChangeFrameNotification, object: nil, queue: nil) { notification in
-            self.keyboardDidChangeFrame(notification)
+        _ = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidChangeFrameNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.keyboardDidChangeFrame(notification)
         }
     }
     


### PR DESCRIPTION
Notification closures were strongly capturing references to the observer thus causing retain cycles that were leading to memory leaks.